### PR TITLE
Change s5 to s5mobile

### DIFF
--- a/src/Italia.DiciottoApp/Models/IdPs.cs
+++ b/src/Italia.DiciottoApp/Models/IdPs.cs
@@ -90,7 +90,7 @@ namespace Italia.DiciottoApp.Models
                     break;
             }
 
-            return (string.IsNullOrWhiteSpace(urlSegment)) ? string.Empty : $"https://sso{(idp == IdP.Test ? "test" : "")}.18app.italia.it/rp/{urlSegment}/s5";
+            return (string.IsNullOrWhiteSpace(urlSegment)) ? string.Empty : $"https://sso{(idp == IdP.Test ? "test" : "")}.18app.italia.it/rp/{urlSegment}/s5mobile";
         }
 
     }


### PR DESCRIPTION
According to Sogei, when doing a login from mobile apps we should use `s5mobile` instead of `s5` in the URL.